### PR TITLE
add linked anchors to steps of how ct works

### DIFF
--- a/layouts/shortcodes/step-by-step-blocks.html
+++ b/layouts/shortcodes/step-by-step-blocks.html
@@ -26,9 +26,9 @@
     <div class='arm-and-description'>
       <div class='arm'>
       </div>
-      <div class='index'>{{ add $index 1 }}</div>
+      <div class='index'><a href="#{{ urlize .Title }}">{{ add $index 1 }}</a></div>
       <div {{if .Params.overflowAt}}data-overflow-at='{{.Params.overflowAt}}' {{end}}class='description'>
-        <h3>{{.Title}}</h3>
+        <h3 id="{{ urlize .Title }}">{{.Title}}</h3>
         <div class='body'>
           {{.Content}}
         </div>


### PR DESCRIPTION
This PR makes each step by step block in `/howctworks` linkable by adding an `id` parameter to each of the `h3` elements.