### PR TITLE
Add openssl example to the known logs doc

### DIFF
--- a/content/google/known-logs.md
+++ b/content/google/known-logs.md
@@ -86,6 +86,18 @@ A test root should:
 For historical reasons, Google's test logs include some test roots that do not
 comply with all of the above requirements.
 
+To verify that your test root complies with the policy listed above, you can run the following `openssl` command:
+```
+$ openssl x509 -in google-test-monitor.cert -noout -serial -issuer -subject -ext keyUsage,basicConstraints
+serial=BF90A6BDBEFC149E
+issuer=C = GB, L = London, O = Google UK Ltd., OU = Certificate Transparency, CN = Test Monitor Root
+subject=C = GB, L = London, O = Google UK Ltd., OU = Certificate Transparency, CN = Test Monitor Root
+X509v3 Key Usage: critical
+    Digital Signature, Certificate Sign
+X509v3 Basic Constraints: critical
+    CA:TRUE
+```
+
 Google's test Logs are:
 
 <pre>


### PR DESCRIPTION
This command should satisfy helping an operator verify the requirements of a test root. Our team lead generated a new Let's Encrypt staging hierarchy and this command helped her verify that our new staging roots meet Google's criteria for acceptance into the testinglog.