### PR TITLE
Fix operators.json link errors.

### DIFF
--- a/data/operators.json
+++ b/data/operators.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "Google",
-      "url": "https://github.com/chromium/ct-policy/blob/master/ct_policy.md#qualifying-certificate ",
+      "url": "https://github.com/chromium/ct-policy/blob/master/ct_policy.md#qualifying-certificate",
       "logo": "google.svg"
     },
     {
@@ -18,7 +18,7 @@
     },
     {
       "name": "Cloudflare",
-      "url": "https://developers.cloudflare.com/ssl/ct-monitoring/",
+      "url": "https://developers.cloudflare.com/ssl/certificate-transparency-monitoring",
       "logo": "cloudflare.svg"
     },
     {


### PR DESCRIPTION
Cloudflares policy page link was returning 404 - updated to what I believe is the correct link. A space character was removed from the end of the Google link meaning the #qualifying-certificate now works as intended (it was previously loading with %20 on the end).