### PR TITLE
Update GH page workflow to align with trillian-website

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,19 +22,19 @@ on:
 jobs:
   build-deploy:
     name: Build and deploy Hugo site
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.60.1'
+        hugo-version: '0.83.1'
         extended: true
 
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
- Bump build image from ubuntu-18.04 to ubuntu-22.04
- Update actions/checkout from master to v3
- Bump actions/cache from v1 to v3
- Bump hugo from 0.60.1 to 0.83.1