### PR TITLE
Grant `pages: write` to "Build/deploy to GH Pages" workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,6 +23,8 @@ jobs:
   build-deploy:
     name: Build and deploy Hugo site
     runs-on: ubuntu-22.04
+    permissions:
+      pages: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix #88.