### PR TITLE
Grant `contents: write` to "Build/deploy to GH Pages" workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build and deploy Hugo site
     runs-on: ubuntu-22.04
     permissions:
-      pages: write
+      contents: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix #88.